### PR TITLE
fixed dns_search module AttributeError

### DIFF
--- a/core/util/hunter.py
+++ b/core/util/hunter.py
@@ -14,42 +14,39 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import json
+
 class main:
 
-	def __init__(self, framework, q, key, limit=10):
+	def __init__(self, framework, q, key, limit=100):
 		""" hunter.io search engine
 
 			framework : core attribute
 			q 		  : query for search
 			key 	  : hunter.io api key
-			limit	  : max number of email addresses (Limited to 10 on Free Plan)
+			limit	  : count of pages
 		"""
 		self.framework = framework
 		self.q = q
 		self.limit = limit
 		self.key = key
-		self.check = ''
 		self._pages = ''
 		self._json_pages = ''
-		self.hunter_api = f"https://api.hunter.io/v2/domain-search?domain={self.q}&api_key={self.key}"
+		self.hunter_api = f"https://api.hunter.io/v2/domain-search?domain={self.q}&api_key={self.key}&limit={self.limit}"
 		self.acceptable = False
 	def run_crawl(self):
 		self.framework.verbose('[HUNTER] Searching in hunter...')
 		try:
-			req = self.framework.request(self.hunter_api)
+			req = requests.get(self.hunter_api)
 		except:
 			self.framework.debug('[HUNTER] ConnectionError')
 			self.framework.error('Hunter is missed!')
 			return
 		self._pages = req.text
-		#print(self._pages)
 		self._json_pages = req.json()
-		print(self._json_pages)
-        # Key validation
+
+		# Key validation
 		if 'errors' in self._json_pages:
-			self.check = self._json_pages['details']
-			self.framework.error(f"[HUNTER] email extraction error:{self.log}")
+			self.framework.error(f"[HUNTER] api key is incurrect:'self.key'")
 			self.acceptable = False
 			return
 
@@ -82,4 +79,4 @@ class main:
 	
 	@property
 	def dns(self):
-		return self.framework.page_parse(self._pages).get_dns(self.q)
+		return self.framework.page_parse(self.pages).get_dns(self.q)

--- a/core/util/hunter.py
+++ b/core/util/hunter.py
@@ -14,24 +14,25 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-
+import json
 class main:
 
-	def __init__(self, framework, q, key, limit=100):
+	def __init__(self, framework, q, key, limit=10):
 		""" hunter.io search engine
 
 			framework : core attribute
 			q 		  : query for search
 			key 	  : hunter.io api key
-			limit	  : count of pages
+			limit	  : max number of email addresses (Limited to 10 on Free Plan)
 		"""
 		self.framework = framework
 		self.q = q
 		self.limit = limit
 		self.key = key
+		self.check = ''
 		self._pages = ''
 		self._json_pages = ''
-		self.hunter_api = f"https://api.hunter.io/v2/domain-search?domain={self.q}&api_key={self.key}&limit={self.limit}"
+		self.hunter_api = f"https://api.hunter.io/v2/domain-search?domain={self.q}&api_key={self.key}"
 		self.acceptable = False
 	def run_crawl(self):
 		self.framework.verbose('[HUNTER] Searching in hunter...')
@@ -42,11 +43,13 @@ class main:
 			self.framework.error('Hunter is missed!')
 			return
 		self._pages = req.text
+		#print(self._pages)
 		self._json_pages = req.json()
-
-		# Key validation
+		print(self._json_pages)
+        # Key validation
 		if 'errors' in self._json_pages:
-			self.framework.error(f"[HUNTER] api key is incurrect:'self.key'")
+			self.check = self._json_pages['details']
+			self.framework.error(f"[HUNTER] email extraction error:{self.log}")
 			self.acceptable = False
 			return
 
@@ -79,4 +82,4 @@ class main:
 	
 	@property
 	def dns(self):
-		return self.framework.page_parse(self.pages).get_dns(self.q)
+		return self.framework.page_parse(self._pages).get_dns(self.q)

--- a/core/util/hunter.py
+++ b/core/util/hunter.py
@@ -36,7 +36,7 @@ class main:
 	def run_crawl(self):
 		self.framework.verbose('[HUNTER] Searching in hunter...')
 		try:
-			req = requests.get(self.hunter_api)
+			req = self.framework.request(self.hunter_api)
 		except:
 			self.framework.debug('[HUNTER] ConnectionError')
 			self.framework.error('Hunter is missed!')

--- a/modules/osint/dns_search.py
+++ b/modules/osint/dns_search.py
@@ -35,7 +35,7 @@ class Module(BaseModule):
 			 True, 'Domain name without https?://', '-d', 'store'),
 			('limit', 3, False, 'Search limit(number of pages, default=3)', '-l', 'store'),
 			('count', 30, False, 'number of results per page(min=10, max=100, default=30)', '-c', 'store'),
-			('engines', None, False, 'Search engine names. e.g bing,google,..', '-e', 'store'),
+			('engines', 'otx', False, 'Search engine names. e.g bing,google,...[otx by default]', '-e', 'store'),
 			('thread', 2, False, 'The number of engine that run per round(default=2)', '-t', 'store'),
 			('max', False, False, 'Using all of sources(max limit=15, max count=50)', '--max', 'store_true'),
 			('validate', False, False, 'Validate the domains(Remove dead subdomains) found and display their IP(default=False)', '--validate', 'store_true'),
@@ -200,8 +200,8 @@ class Module(BaseModule):
 		engines = self.options['engines']
 		if self.options['silent']:
 			self._global_options['verbosity'] = 0
-		if not engines:
-			engines = 'threatcrowd,otx'
+		if engines == None:
+			engines = 'otx'
 
 		engines = self.meta['sources'] if MAX else self.options['engines'].lower().split(',')
 		self.thread(self.search, self.options['thread'], engines, domain_name, limit, count)


### PR DESCRIPTION
On running the `dns_search` module without any engine specified. It gave the following error:
```
[maryam][default] > dns_search -d github.com
[!] File "/home/path/to/Maryam/modules/osint/dns_search.py", line 206, in module_run.
[!] AttributeError: 'NoneType' object has no attribute 'lower'.
```
The following line above it needed a fix:
```
if not engines:
     engines = 'threatcrowd,otx'
```
(Added otx as default subdomain search module and changed Nonetype of engine to 'otx' in meta. Please check the latest commit and ignore the older ones)