### PR TITLE
Improve command history access and code reformat

### DIFF
--- a/core/framework.py
+++ b/core/framework.py
@@ -23,16 +23,17 @@ import os
 import re
 import subprocess
 import sys
-import signal
 import traceback
 import requests
-import shlex
+import readline
 from core.util import rand_uagent
 from io import StringIO
+
 
 class FrameworkException(Exception):
 	def __init__(self, message):
 		Exception.__init__(self, message)
+
 
 class Colors(object):
 	N = '\033[m'  # native
@@ -122,6 +123,7 @@ class Framework(cmd.Cmd):
 	_summary_counts = {}
 	Colors = Colors
 	_history_file = ''
+
 	def __init__(self, params):
 		cmd.Cmd.__init__(self)
 		self._modulename = params
@@ -135,6 +137,12 @@ class Framework(cmd.Cmd):
 	# ==================================================
 	# CMD OVERRIDE METHODS
 	# ==================================================
+
+	def preloop(self):
+		self._init_history()
+		history = self._history_file.name
+		if readline and os.path.exists(history):
+			readline.read_history_file(history)
 
 	def default(self, line):
 		self.do_shell(line)
@@ -162,7 +170,7 @@ class Framework(cmd.Cmd):
 
 	def onecmd(self, line):
 		line = self.to_unicode(line)
-		# Log commant into the history file if 'history' is true
+		# Log command into the history file if 'history' is true
 		if self._global_options['history']:
 			self._log_commands(line)
 		cmd, arg, line = self.parseline(line)

--- a/core/framework.py
+++ b/core/framework.py
@@ -139,7 +139,6 @@ class Framework(cmd.Cmd):
 	# ==================================================
 
 	def preloop(self):
-		self._init_history()
 		history = self._history_file.name
 		if readline and os.path.exists(history):
 			readline.read_history_file(history)


### PR DESCRIPTION
Previously the up arrow key helps to access old commands within that particular session only however this PR adds support for accessing commands from the previous sessions as well with the up arrow key. I have also remove few unnecessary imports and did some code reformat according to PEP8 standards.