### PR TITLE
Fixed social_nets module TypeError

### DIFF
--- a/modules/osint/social_nets.py
+++ b/modules/osint/social_nets.py
@@ -82,7 +82,7 @@ class Module(BaseModule):
 			if lst != []:
 				self.alert(net)
 				for link in lst:
-					if type(link) is tuple:
+					if type(link) is list:
 						link = list(link).pop(link.index(''))
 						for mic in link:
 							if len(mic) > 2:


### PR DESCRIPTION
The following module gave TypeError since lst was `<class 'list'>`  and not `tuple` .
```
[!] File "/home/path/to/Maryam/modules/osint/social_nets.py", line 86, in module_run.
[!] ValueError: tuple.index(x): x not in tuple.
```

Above error is now fixed.