### PR TITLE
filter google search links

### DIFF
--- a/core/util/google.py
+++ b/core/util/google.py
@@ -70,7 +70,7 @@ class main:
 			payload['start'] = set_page(page)
 			if page >= self.limit:
 				break
-		links = self.framework.page_parse(self._pages).findall(r'a href=".*?(https?[^"]+)"')
+		links = self.framework.page_parse(self._pages).findall(r'a href="([^"]+)"')
 
 		for link in links:
 			cond1 = 'https://support.google.com/' not in link.lower()
@@ -78,7 +78,9 @@ class main:
 			cond3 = "://" in link
 			if cond1 and cond2 and cond3:
 				url = self.framework.urlib(link).unquote_plus
-				self._links.append(url[:url.find("&amp")])
+				url = re.sub(r"^\/url\?q=", '', url)
+				url = re.sub(r'\&amp.+', '', url)
+				self._links.append(url)
 
 	def api_run_crawl(self):
 		if not (self.google_api and self.google_cx):

--- a/core/util/google.py
+++ b/core/util/google.py
@@ -75,8 +75,9 @@ class main:
 		for link in links:
 			cond1 = 'https://support.google.com/' not in link.lower()
 			cond2 = 'https://www.google.com/webhp' not in link.lower()
-			cond3 = "://" in link
-			if cond1 and cond2 and cond3:
+			cond3 = '://' in link
+			cond4 = 'https://www.google.com/search?' not in link.lower()
+			if cond1 and cond2 and cond3 and cond4:
 				url = self.framework.urlib(link).unquote_plus
 				self._links.append(url[:url.find("&amp")])
 

--- a/core/util/google.py
+++ b/core/util/google.py
@@ -70,14 +70,15 @@ class main:
 			payload['start'] = set_page(page)
 			if page >= self.limit:
 				break
-		links = self.framework.page_parse(self._pages).findall(r'a href="([^"]+)"')
+		links = self.framework.page_parse(self._pages).findall(r'a href=".*?(https?[^"]+)"')
 
 		for link in links:
 			cond1 = 'https://support.google.com/' not in link.lower()
 			cond2 = 'https://www.google.com/webhp' not in link.lower()
 			cond3 = "://" in link
 			if cond1 and cond2 and cond3:
-				self._links.append(self.framework.urlib(link).unquote_plus)
+				url = self.framework.urlib(link).unquote_plus
+				self._links.append(url[:url.find("&amp")])
 
 	def api_run_crawl(self):
 		if not (self.google_api and self.google_cx):


### PR DESCRIPTION
This PR extracts the correct url for each link.

![image](https://user-images.githubusercontent.com/33282622/110007529-72e6fc80-7d23-11eb-88e0-bd0dd27a7d91.png)


I couldn't figure a regex to filter out the &amp part so I used find()