### PR TITLE
Fix docs_search error with  bing

### DIFF
--- a/core/util/bing.py
+++ b/core/util/bing.py
@@ -93,4 +93,4 @@ class main:
 
 	@property
 	def docs(self):
-		return self.framework.page_parse(self._pages).get_docs(self.links)
+		return self.framework.page_parse(self._pages).get_docs(self.q, self.links)


### PR DESCRIPTION
Docs search with bing was showing error as self.links(list) was being passed instead of the query