### PR TITLE
fixed stackoverflow error and allowed redirects for search engines

### DIFF
--- a/core/util/carrot2.py
+++ b/core/util/carrot2.py
@@ -43,7 +43,7 @@ class main:
 				   'Upgrade-Insecure-Requests': '1', 'Cache-Control': 'max-age=0'}
 		self.framework.debug(f"[eTOOLS] Searching in 'etools.ch'...")
 		try:
-			req = self.framework.request(url=self.etools, params=params, headers=headers)
+			req = self.framework.request(url=self.etools, params=params, headers=headers,allow_redirects=True)
 		except:
 			self.framework.error('[eTOOLS] ConnectionError')
 			self.framework.error('eTOOLS is missed!')

--- a/core/util/yahoo.py
+++ b/core/util/yahoo.py
@@ -41,7 +41,7 @@ class main:
 		for url in range(len(urls)):
 			self.framework.verbose(f"[YAHOO] Searching in {url} page...")
 			try:
-				req = self.framework.request(url=urls[url])
+				req = self.framework.request(url=urls[url],allow_redirects=True)
 			except:
 				self.framework.error('[YAHOO] ConnectionError')
 				max_attempt -= 1

--- a/modules/search/stackoverflow.py
+++ b/modules/search/stackoverflow.py
@@ -68,12 +68,12 @@ def module_api(self):
 	self.thread(search, self.options['thread'], engine, query, q_formats, limit, count, meta['sources'])
 	links = list(self.reglib().filter(r'https?://(www\.)?stackoverflow\.com', list(set(LINKS))))
 	for link in links:
-		first_type = re.search(r'stackoverflow\.com/questions/[\d]+/([\w\d\-_]+)/?', link)
+		first_type = re.search(r'stackoverflow\.com/[Qq]uestions/[\d]*/([\w\d\-_]+)/?', link)
 		if first_type:
 			title = first_type.group(1).replace('-', ' ').title()
 			title = self.urlib(title).unquote.title()
 		else:
-			title = 'Without Title'
+			title = 'Matching Result [Without Title]'
 		output['links'].append([link, title])
 
 	for link in links:
@@ -92,9 +92,8 @@ def module_api(self):
 
 def module_run(self):
 	output = module_api(self)
-	for i in range(len(output['titles'])):
-		self.output(output['titles'][i])
-		self.output(f"\t{output['links'][i]}", 'G')
-	output.pop('titles')
+	for i in range(len(output['links'])):
+		self.output(f"{output['links'][i][1]}", 'G')
+		self.output(f"\t{output['links'][i][0]}", 'G')
 	output.pop('links')
 	self.alert_results(output)


### PR DESCRIPTION
Stackoverflow had this error:
```
╰──> λ ./maryam -e stackoverflow -q windows -e google,bing,yahoo
[*] [GOOGLE] Searching in 1 page...
[*] [BING] Searching in 0 page...
[*] [YAHOO] Searching in 0 page...
[!] StackoverflowCodeError: 'titles'.
```
And search engines had no redirections to reach original links. Solved. Now links work.
```
[*] Matching Result [Without Title]
[*] 	https://www.stackoverflow.com/a/48580627
[*] How Do I Add A Custom Routed Command In Wpf
[*] 	http://www.stackoverflow.com/Questions/601393/how-do-i-add-a-custom-routed-command-in-wpf
[*] Batch File To Delete Files Older Than N Days
[*] 	http://www.stackoverflow.com/Questions/51054/batch-file-to-delete-files-older-than-n-days
[*] Matching Result [Without Title]
```
