### PR TITLE
username_search now works when invoked from outside cloned dir

### DIFF
--- a/modules/osint/username_search.py
+++ b/modules/osint/username_search.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import json
 import concurrent.futures
+from os.path import dirname as up
 
 meta = {
 	'name': 'Username Search',
@@ -26,8 +27,8 @@ meta = {
 	'description': 'Search your query across 100+ social networks and show the results.',
 	'sources': ('https://github.com/sherlock-project/sherlock',),
 	'options': (
-		('query', None, True, 'Query string', '-q', 'store', str),
-		('thread', 64, False, 'The number of sites that are being checked per round(default=8)', '-t', 'store', int),
+	        ('query', None, True, 'Query string', '-q', 'store', str),
+	        ('thread', 64, False, 'The number of sites that are being checked per round(default=8)', '-t', 'store', int),
 	),
     'examples': ('username_search -q <QUERY> --output',)
 }
@@ -38,30 +39,33 @@ def thread(self, data, query,thread_count):
 	threadpool = concurrent.futures.ThreadPoolExecutor(max_workers=thread_count)
 	futures = (threadpool.submit(check, self, data[site]['url'].format(query), site, data) for site in data)
 	for results in concurrent.futures.as_completed(futures):
-		print(f"Found {len(OUTPUT['links'])} accounts" , end= '\r')
+	        print(f"Found {len(OUTPUT['links'])} accounts" , end= '\r')
 	print('\n')
 
 
 def check(self, url, site, data):
 	global OUTPUT
 	try:
-		headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
-		req = self.request(url , headers=headers,timeout=20)
+	        headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
+	        req = self.request(url , headers=headers,timeout=20)
 	except Exception as e:
-		return
+	        return
 	else:
-		if str(req.status_code) == data[site]['status'] :
-			for error in data[site]['error'] :
-				if error in req.text :
-					return
-		else:
-			OUTPUT['links'][site] = url
+	        if str(req.status_code) == data[site]['status'] :
+	                for error in data[site]['error'] :
+	                        if error in req.text :
+	                                return
+	        else:
+	                OUTPUT['links'][site] = url
 
 def module_api(self):
 	query = self.options['query']
-	filepath = os.path.join(os.getcwd(), 'data', 'username_checker.json')
-	with open(filepath) as file:
-		data = json.loads(file.read())
+	project_root = up(up(up(__file__)))
+	filepath = os.path.join(project_root,
+	                        'data',
+	                        'username_checker.json')
+	with open(filepath) as handle:
+	        data = json.load(handle)
 	thread(self, data, query,self.options['thread'])
 	output = OUTPUT
 


### PR DESCRIPTION
Previously `username_checker` did not work when executed from another directory because the username_checker json path was appended to `os.cwd`.

This was fixed using
```
from os.path import dirname as up 
project_root = up(up(up(__file__)))
filepath = os.path.join(project_root, 
                       'data', 
                       'username_checker.json')
```
