### PR TITLE
username_search now works when invoked from outside cloned dir

### DIFF
--- a/modules/footprint/dnsbrute.py
+++ b/modules/footprint/dnsbrute.py
@@ -18,7 +18,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import concurrent.futures
 from socket import gethostbyname
+from os.path import dirname as up
 
+ROOT = up(up(up(os.path.realpath(__file__))))
 meta = {
 	'name': 'DNS Brute Force',
 	'author': 'Saeeddqn',
@@ -29,8 +31,8 @@ meta = {
 		('domain', None, False, 'Domain name without https?://', '-d', 'store', str),
 		('count', None, False, 'Number of payloads len(max=count of payloads). default is max',
 							 '-c', 'store', int),
-		('wordlist', os.path.join(os.getcwd() + '/' + 'data', 'dnsnames.txt'), False, 
-							'wordlist address. default is dnsnames.txt in data folder', '-w', 'store', str),
+		('wordlist', os.path.join(ROOT, 'data', 'dnsnames.txt'), False, 
+			   'wordlist address. default is dnsnames.txt in data folder', '-w', 'store', str),
 		('thread', 8, False, 'The number of links that open per round(default=8)', '-t', 'store', int),
 		('wordlists', False, False, 'List of most common DNS wordlists', '-l', 'store_true', bool),
 		('ips', False, False, 'Show ip addresses', '-i', 'store_true', bool),

--- a/modules/footprint/dnsbrute.py
+++ b/modules/footprint/dnsbrute.py
@@ -1,16 +1,13 @@
 """
 OWASP Maryam!
-
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 any later version.
-
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
-
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
@@ -45,7 +42,7 @@ HOSTNAMES = []
 LISTS = {"https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/DNS/subdomains-top1million-5000.txt": 'small',
 		 "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/DNS/fierce-hostlist.txt": 'small',
 		 "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/DNS/namelist.txt": 'small',
-		 "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/DNS/subdomains-top1million-20000.txt": 'mediom',
+		 "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/DNS/subdomains-top1million-20000.txt": 'medium',
 		 "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/DNS/subdomains-top1million-110000.txt": 'large',
 		 "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/DNS/deepmagic.com-prefixes-top50000.txt": 'large',
 		 "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/DNS/shubs-subdomains.txt": 'large'

--- a/modules/footprint/tldbrute.py
+++ b/modules/footprint/tldbrute.py
@@ -20,8 +20,8 @@ import concurrent.futures
 from socket import gethostbyname
 from os.path import dirname as up
 
-ROOT = up(up(up(os.path.realpath(__file__))))
 
+ROOT = up(up(up(os.path.realpath(__file__))))
 meta = {
 	'name': 'DNS Brute Force',
 	'author': 'Saeed',

--- a/modules/footprint/tldbrute.py
+++ b/modules/footprint/tldbrute.py
@@ -18,6 +18,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import concurrent.futures
 from socket import gethostbyname
+from os.path import dirname as up
+
+ROOT = up(up(up(os.path.realpath(__file__))))
 
 meta = {
 	'name': 'DNS Brute Force',
@@ -29,7 +32,7 @@ meta = {
 		('domain', None, True, 'Domain name without https?://', '-d', 'store', str),
 		('count', None, False, 'Number of payloads len(max=count of payloads). default is max',
 							 '-c', 'store', int),
-		('wordlist', os.path.join(os.getcwd() + '/' + 'data', 'tlds.txt'), False, 
+		('wordlist', os.path.join(ROOT, 'data', 'tlds.txt'), False, 
 							'wordlist address. default is dnsnames.txt in data folder', '-w', 'store', str),
 		('thread', 8, False, 'The number of links that open per round(default=8)', '-t', 'store', int),
 		('ips', False, False, 'Show ip addresses', '-i', 'store_true', bool),

--- a/modules/osint/username_search.py
+++ b/modules/osint/username_search.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import json
 import concurrent.futures
+from os.path import dirname as up
 
 meta = {
 	'name': 'Username Search',
@@ -26,8 +27,8 @@ meta = {
 	'description': 'Search your query across 100+ social networks and show the results.',
 	'sources': ('https://github.com/sherlock-project/sherlock',),
 	'options': (
-		('query', None, True, 'Query string', '-q', 'store', str),
-		('thread', 64, False, 'The number of sites that are being checked per round(default=8)', '-t', 'store', int),
+	        ('query', None, True, 'Query string', '-q', 'store', str),
+	        ('thread', 64, False, 'The number of sites that are being checked per round(default=8)', '-t', 'store', int),
 	),
     'examples': ('username_search -q <QUERY> --output',)
 }
@@ -38,30 +39,33 @@ def thread(self, data, query,thread_count):
 	threadpool = concurrent.futures.ThreadPoolExecutor(max_workers=thread_count)
 	futures = (threadpool.submit(check, self, data[site]['url'].format(query), site, data) for site in data)
 	for results in concurrent.futures.as_completed(futures):
-		print(f"Found {len(OUTPUT['links'])} accounts" , end= '\r')
+	        print(f"Found {len(OUTPUT['links'])} accounts" , end= '\r')
 	print('\n')
 
 
 def check(self, url, site, data):
 	global OUTPUT
 	try:
-		headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
-		req = self.request(url , headers=headers,timeout=20)
+	        headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
+	        req = self.request(url , headers=headers,timeout=20)
 	except Exception as e:
-		return
+	        return
 	else:
-		if str(req.status_code) == data[site]['status'] :
-			for error in data[site]['error'] :
-				if error in req.text :
-					return
-		else:
-			OUTPUT['links'][site] = url
+	        if str(req.status_code) == data[site]['status'] :
+	                for error in data[site]['error'] :
+	                        if error in req.text :
+	                                return
+	        else:
+	                OUTPUT['links'][site] = url
 
 def module_api(self):
 	query = self.options['query']
-	filepath = os.path.join(os.getcwd(), 'data', 'username_checker.json')
-	with open(filepath) as file:
-		data = json.loads(file.read())
+	project_root = up(up(up(__file__)))
+	filepath = os.path.join(project_root,
+	                        'data',
+	                        'username_checker.json')
+	with open(filepath) as handle:
+	        data = json.load(handle)
 	thread(self, data, query,self.options['thread'])
 	output = OUTPUT
 

--- a/modules/osint/username_search.py
+++ b/modules/osint/username_search.py
@@ -27,10 +27,10 @@ meta = {
 	'description': 'Search your query across 100+ social networks and show the results.',
 	'sources': ('https://github.com/sherlock-project/sherlock',),
 	'options': (
-	        ('query', None, True, 'Query string', '-q', 'store', str),
-	        ('thread', 64, False, 'The number of sites that are being checked per round(default=8)', '-t', 'store', int),
+		('query', None, True, 'Query string', '-q', 'store', str),
+		('thread', 64, False, 'The number of sites that are being checked per round(default=8)', '-t', 'store', int),
 	),
-    'examples': ('username_search -q <QUERY> --output',)
+	'examples': ('username_search -q <QUERY> --output',)
 }
 
 OUTPUT = {'links': {}}
@@ -39,33 +39,33 @@ def thread(self, data, query,thread_count):
 	threadpool = concurrent.futures.ThreadPoolExecutor(max_workers=thread_count)
 	futures = (threadpool.submit(check, self, data[site]['url'].format(query), site, data) for site in data)
 	for results in concurrent.futures.as_completed(futures):
-	        print(f"Found {len(OUTPUT['links'])} accounts" , end= '\r')
+		print(f"Found {len(OUTPUT['links'])} accounts" , end= '\r')
 	print('\n')
 
 
 def check(self, url, site, data):
 	global OUTPUT
 	try:
-	        headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
-	        req = self.request(url , headers=headers,timeout=20)
+		headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}
+		req = self.request(url , headers=headers,timeout=20)
 	except Exception as e:
-	        return
+		return
 	else:
-	        if str(req.status_code) == data[site]['status'] :
-	                for error in data[site]['error'] :
-	                        if error in req.text :
-	                                return
-	        else:
-	                OUTPUT['links'][site] = url
+		if str(req.status_code) == data[site]['status'] :
+			for error in data[site]['error'] :
+				if error in req.text :
+					return
+		else:
+			OUTPUT['links'][site] = url
 
 def module_api(self):
 	query = self.options['query']
 	project_root = up(up(up(__file__)))
 	filepath = os.path.join(project_root,
-	                        'data',
-	                        'username_checker.json')
+				'data',
+				'username_checker.json')
 	with open(filepath) as handle:
-	        data = json.load(handle)
+		data = json.load(handle)
 	thread(self, data, query,self.options['thread'])
 	output = OUTPUT
 


### PR DESCRIPTION
Previously `username_checker` did not work when executed from another directory because the username_checker json path was appended to `os.cwd`.

This was fixed using
```
from os.path import dirname as up 
project_root = up(up(up(__file__)))
filepath = os.path.join(project_root, 
                       'data', 
                       'username_checker.json')
```

Also,
`data = json.loads(handle.read())`
was replaced with
`data = json.load(handle)`

Closed the previous PR to fix my editor's tab settings and recommit