### PR TITLE
Added arxiv engine and module

### DIFF
--- a/core/util/arxiv.py
+++ b/core/util/arxiv.py
@@ -39,8 +39,7 @@ class main:
                 self.q = urllib.parse.quote_plus(self.q)
                 url = f'https://export.arxiv.org/api/query?search_query=all:'\
                            + f'{self.q}&start=0&max_results={self.max}'
-                self.framework.verbose('Opening the arxiv.org domain...')
-                self.framework.verbose(f"[ARXIV] Searching in {url}...")
+                self.framework.verbose('Searching the arxiv.org domain...')
                 try:
                         req = self.framework.request(url=url)
                 except:

--- a/core/util/arxiv.py
+++ b/core/util/arxiv.py
@@ -1,0 +1,81 @@
+"""
+OWASP Maryam!
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import re
+import urllib.parse
+import html
+
+class main:
+
+        def __init__(self, q, limit=15):
+                """ arxiv.org search engine
+
+                        q         : query for search
+                        limit     : maximum result count
+                """
+                self.framework = main.framework
+                self.q = q
+                self.max = limit
+                self._rawxml = ''
+                self._articles = []
+                self._links = []
+                self._links_with_data = []
+
+        def run_crawl(self):
+                self.q = urllib.parse.quote_plus(self.q)
+                url = f'https://export.arxiv.org/api/query?search_query=all:'\
+                           + f'{self.q}&start=0&max_results={self.max}'
+                self.framework.verbose('Opening the arxiv.org domain...')
+                self.framework.verbose(f"[ARXIV] Searching in {url}...")
+                try:
+                        req = self.framework.request(url=url)
+                except:
+                        self.framework.error('[ARXIV] ConnectionError')
+                        self.framework.error('ArXiv is missed!')
+                        return
+                self._rawxml = req.text
+                self._articles = list(re.findall('(?<=<entry>).*?(?=</entry>)', 
+                        self._rawxml, 
+                        flags=re.DOTALL))
+
+        @property
+        def raw(self):
+                return self._rawxml
+
+        @property
+        def articles(self):
+                return self._articles
+
+        @property
+        def links(self):
+                self._links = re.findall('http://arxiv.org/abs/.*(?=<)',
+                        self._rawxml)
+                return self._links
+
+        @property
+        def links_with_data(self):
+                findlink = lambda x: re.findall('http://arxiv.org/abs/.*?(?=<)', x)
+                findauthors = lambda x: re.findall('(?<=<name>).*?(?=</name>)', x)
+                findtitle = lambda x: re.findall('(?<=<title>).*?(?=</title>)', x, flags=re.DOTALL)
+
+                for article in self._articles:
+                        self._links_with_data.append({'authors':findauthors(article),
+                                'title': list(map(html.unescape,findtitle(article))),
+                                'link' : findlink(article)
+                                })
+
+                return self._links_with_data

--- a/modules/search/arxiv.py
+++ b/modules/search/arxiv.py
@@ -1,0 +1,52 @@
+"""
+OWASP Maryam!
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+
+meta = {
+        'name': 'ArXiv',
+        'author': 'Kaushik',
+        'version': '0.1',
+        'description': 'ArXiv is a scientific research repository \
+                with a public API for searching its articles and papers',
+        'sources': ('arxiv'),
+        'options': (
+                ('query', None, True, 'Query string', '-q', 'store', str),
+                ('limit', 15, False, 'Max result count (default=15)', '-l', 'store', int),
+        ),
+        'examples': ('arxiv -q <QUERY> -l 15 --output',)
+}
+
+def module_api(self):
+        query = self.options['query']
+        limit = self.options['limit']
+        run = self.arxiv(query, limit)
+        run.run_crawl()
+        output = {'results': []}
+        links = run.links_with_data
+
+        for item in links:
+                output['results'].append(item)
+
+        self.save_gather(output, 'search/arxiv', query, output=self.options['output'])
+        return output
+
+def module_run(self):
+        output = module_api(self)['results']
+        for item in output:
+                print()
+                self.output(item['title'][0])
+                self.output(','.join(item['authors'][:5]))
+                if len(item['authors'])>5:
+                	self.output(','.join(item['authors'][5:]))
+                self.output(item['link'][0])


### PR DESCRIPTION
_'arXiv is a free distribution service and an open-access archive for 1,858,906 scholarly articles in the fields of physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, electrical engineering and systems science, and economics'_

arXiv.org also has a public API which returns an xml:rss document of the search results.  
Currently parsing the xml using regex, which works fine, but would like to migrate to a dedicated xml
parser if one is built for maryam.  


![Screenshot 2021-03-29 at 5 20 33 PM](https://user-images.githubusercontent.com/59250093/112832530-13c2a080-90b3-11eb-8a00-e87161e20555.png)


