### PR TITLE
Added piratebay engine

### DIFF
--- a/core/util/piratebay.py
+++ b/core/util/piratebay.py
@@ -1,0 +1,91 @@
+"""
+OWASP Maryam!
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import re
+import urllib.parse
+import html
+
+class main:
+
+        def __init__(self, q, limit=15):
+                """ piratebay search engine
+
+                        q         : query for search
+                        limit     : maximum result count
+                """
+                self.framework = main.framework
+                self.q = q
+                self.max = limit
+                self._rawhtml = ''
+                self._torrents = []
+                self._magnets = []
+                self._rows = []
+                self._links_with_data = []
+
+        def run_crawl(self):
+                self.q = urllib.parse.quote(self.q)
+                url = f'https://tpb.party/search/{self.q}'
+                self.framework.verbose('Searching piratebay...')
+                try:
+                        req = self.framework.request(url=url)
+                except:
+                        self.framework.error('[PIRATEBAY] ConnectionError')
+                        self.framework.error('Piratebay is missed!')
+                        return
+                self._rawhtml = req.text
+                self._torrents = list(re.findall('(?<=<tr>).*?(?=</tr>)', 
+                        self._rawhtml, 
+                        flags=re.DOTALL))
+
+        @property
+        def raw(self):
+                return self._rawhtml
+
+        @property
+        def links_with_data(self):
+                findtitle = lambda x: re.findall('(?<=Details for ).*?(?=">)', x, flags=re.DOTALL)
+                magnet_regex = '(?<=<a href=")magnet:.*?(?=" title="Download this torrent using magnet">)'
+                findmagnet = lambda x: re.findall(magnet_regex, x)
+                finduploader = lambda x: re.findall('(?<=title="Browse ).*?(?=")', x)
+                finddatesize = lambda x: re.findall('Uploaded .*?, ULed by', x)
+                seedandleech = lambda x: re.findall( '(?<=<td align="right">).*?(?=</td>)', x)
+                
+
+                limitcount = 0
+                for torrent in self._torrents:
+                        limitcount+=1
+                        if limitcount>self.max:
+                            break
+
+                        title = findtitle(torrent)
+                        magnet = findmagnet(torrent)
+                        uploader = finduploader(torrent)
+                        date = finddatesize(torrent)
+                        seedleechcount = seedandleech(torrent)
+
+                        if len(title)==len(magnet)==len(uploader)==len(date)==1\
+                        and len(seedleechcount)==2:
+                                self._links_with_data.append({
+                                        'title': html.unescape(title[0]),
+                                        'date': html.unescape(date[0]),
+                                        'uploader': uploader[0],
+                                        'magnet' : magnet[0],
+                                        'seeders': seedleechcount[0],
+                                        'leechers': seedleechcount[1]
+                                        })
+
+                return self._links_with_data

--- a/modules/search/piratebay.py
+++ b/modules/search/piratebay.py
@@ -1,0 +1,52 @@
+"""
+OWASP Maryam!
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+
+meta = {
+        'name': 'Piratebay',
+        'author': 'Kaushik',
+        'version': '0.1',
+        'description': 'Piratebay is the world\'s most persistent torrenting site\
+                 Please refrain from abusive usage.',
+        'sources': ('piratebay'),
+        'options': (
+                ('query', None, True, 'Query string', '-q', 'store', str),
+                ('limit', 15, False, 'Max result count (default=15)', '-l', 'store', int),
+        ),
+        'examples': ('piratebay -q <QUERY> -l 15 --output',)
+}
+
+def module_api(self):
+        query = self.options['query']
+        limit = self.options['limit']
+        run = self.piratebay(query, limit)
+        run.run_crawl()
+        output = {'results': []}
+        links = run.links_with_data
+
+        for item in links:
+                output['results'].append(item)
+
+        self.save_gather(output, 'search/piratebay', query, output=self.options['output'])
+        return output
+
+def module_run(self):
+        output = module_api(self)['results']
+        for item in output:
+                print()
+                self.output(item['title'])
+                self.output(item['magnet'])
+                self.output(item['date']+' '+item['uploader'])
+                self.output('Seeders  :'+item['seeders'])
+                self.output('Leechers :'+item['leechers'])

--- a/modules/search/piratebay.py
+++ b/modules/search/piratebay.py
@@ -17,7 +17,7 @@ meta = {
         'name': 'Piratebay',
         'author': 'Kaushik',
         'version': '0.1',
-        'description': 'Piratebay is the world\'s most persistent torrenting site\
+        'description': 'Piratebay is the world\'s most persistent torrenting site. \
                  Please refrain from abusive usage.',
         'sources': ('piratebay'),
         'options': (


### PR DESCRIPTION
_Piratebay is the world's largest torrenting site_

This module grabs torrents matching the search query, sorted by seeder count.
Currently using the proxy `tpb.party` because `thepiratebay.org` redirects to it.
Will update if it goes down or if someone points out a better way.


![Screenshot 2021-03-29 at 10 08 49 PM](https://user-images.githubusercontent.com/59250093/112869972-58fac880-90db-11eb-9640-342b26aee454.png)


(The long string is a magnet link that can be pasted into a torrent client to start downloading the corresponding torrent.)
Please refrain from torrenting paid software/media.
