### PR TITLE
Add basedir.py and remove ugly up(up(up(__file__)))

### DIFF
--- a/core/basedir.py
+++ b/core/basedir.py
@@ -1,0 +1,3 @@
+import os
+
+BASEDIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../"))

--- a/core/basedir.py
+++ b/core/basedir.py
@@ -1,3 +1,3 @@
 import os
 
-BASEDIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../"))
+BASEDIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../'))

--- a/modules/footprint/dnsbrute.py
+++ b/modules/footprint/dnsbrute.py
@@ -15,9 +15,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import concurrent.futures
 from socket import gethostbyname
-from os.path import dirname as up
 
-ROOT = up(up(up(os.path.realpath(__file__))))
+from core.basedir import BASEDIR
+
 meta = {
 	'name': 'DNS Brute Force',
 	'author': 'Saeeddqn',
@@ -28,14 +28,14 @@ meta = {
 		('domain', None, False, 'Domain name without https?://', '-d', 'store', str),
 		('count', None, False, 'Number of payloads len(max=count of payloads). default is max',
 							 '-c', 'store', int),
-		('wordlist', os.path.join(ROOT, 'data', 'dnsnames.txt'), False, 
+		('wordlist', os.path.join(BASEDIR, 'data', 'dnsnames.txt'), False, 
 			   'wordlist address. default is dnsnames.txt in data folder', '-w', 'store', str),
 		('thread', 8, False, 'The number of links that open per round(default=8)', '-t', 'store', int),
 		('wordlists', False, False, 'List of most common DNS wordlists', '-l', 'store_true', bool),
 		('ips', False, False, 'Show ip addresses', '-i', 'store_true', bool),
 	),
-	'examples': ('dbrute -d <DOMAIN> --output',
-				'dbrute -d <DOMAIN> -w <WORDLIST>')
+	'examples': ('dnsbrute -d <DOMAIN> --output',
+				'dnsbrute -d <DOMAIN> -w <WORDLIST>')
 }
 
 HOSTNAMES = []

--- a/modules/footprint/tldbrute.py
+++ b/modules/footprint/tldbrute.py
@@ -18,10 +18,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import concurrent.futures
 from socket import gethostbyname
-from os.path import dirname as up
 
+from core.basedir import BASEDIR
 
-ROOT = up(up(up(os.path.realpath(__file__))))
 meta = {
 	'name': 'DNS Brute Force',
 	'author': 'Saeed',
@@ -32,7 +31,7 @@ meta = {
 		('domain', None, True, 'Domain name without https?://', '-d', 'store', str),
 		('count', None, False, 'Number of payloads len(max=count of payloads). default is max',
 							 '-c', 'store', int),
-		('wordlist', os.path.join(ROOT, 'data', 'tlds.txt'), False, 
+		('wordlist', os.path.join(BASEDIR, 'data', 'tlds.txt'), False, 
 							'wordlist address. default is dnsnames.txt in data folder', '-w', 'store', str),
 		('thread', 8, False, 'The number of links that open per round(default=8)', '-t', 'store', int),
 		('ips', False, False, 'Show ip addresses', '-i', 'store_true', bool),

--- a/modules/osint/bing_mobile_view.py
+++ b/modules/osint/bing_mobile_view.py
@@ -14,12 +14,13 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-import re
+
 import os
 import urllib
 import json
 import datetime
-from os.path import dirname as up 
+
+from core.basedir import BASEDIR
 
 meta = {
 	'name': 'Bing Mobile View',
@@ -36,11 +37,8 @@ meta = {
 	'examples': ('bing_mobile_view -u <URL>',)
 }
 
-project_root = up(up(up(__file__)))
-
 def blacklist_check(self, image_data):
-	global project_root
-	black_img_path = os.path.join(project_root, 'data', 'images', 'blacklist', f'{self.options["blacklist"]}.json')
+	black_img_path = os.path.join(BASEDIR, 'data', 'images', 'blacklist', f'{self.options["blacklist"]}.json')
 	if not os.path.isfile(black_img_path) : # Check if blacklisted image exists?
 		self.error('The blacklisted image name entered by user does not exist.', 'bing_mobile_view', 'blacklist_check')
 		return False
@@ -63,7 +61,6 @@ def blacklist_check(self, image_data):
 		return image_data
 
 def module_api(self):
-	global project_root
 	url = self.options['url']
 	blacklisted_img_name = self.options['blacklist']
 	retries = self.options['retries']
@@ -103,7 +100,7 @@ def module_api(self):
 	else urllib.parse.quote_plus(url) #Folder name is the domain name. If empty then folder name == URL
 	file_name = f"{urllib.parse.quote_plus(url)} {str(datetime.datetime.now())}.jpg" #File name is url encode+timestamp
 	
-	folder_filepath = os.path.join(project_root, 'data', 'images', folder_name)
+	folder_filepath = os.path.join(BASEDIR, 'data', 'images', folder_name)
 
 	if not os.path.isdir(folder_filepath) : # If no pre-existing folder for image, make one
 		os.mkdir(folder_filepath)

--- a/modules/osint/username_search.py
+++ b/modules/osint/username_search.py
@@ -18,7 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import json
 import concurrent.futures
-from os.path import dirname as up
+
+from core.basedir import BASEDIR
 
 meta = {
 	'name': 'Username Search',
@@ -60,8 +61,7 @@ def check(self, url, site, data):
 
 def module_api(self):
 	query = self.options['query']
-	project_root = up(up(up(__file__)))
-	filepath = os.path.join(project_root,
+	filepath = os.path.join(BASEDIR,
 				'data',
 				'username_checker.json')
 	with open(filepath) as handle:
@@ -99,7 +99,7 @@ def refresh_username_checker_siteranks():
 	https://www.domcop.com/openpagerank/
 	"""
 	import requests
-	from urllib.parse import urlparse, quote
+	from urllib.parse import urlparse
 
 	API_KEY = input('Please input your OpenSiteRank API key: ')
 
@@ -112,8 +112,7 @@ def refresh_username_checker_siteranks():
 
 	data = dict()
 
-	project_root = up(up(up(__file__)))
-	filepath = os.path.join(project_root,
+	filepath = os.path.join(BASEDIR,
 				'data',
 				'username_checker.json')
 

--- a/modules/osint/username_search.py
+++ b/modules/osint/username_search.py
@@ -38,9 +38,9 @@ OUTPUT = {'links': {}}
 
 def thread(self, data, query,thread_count):
 	threadpool = concurrent.futures.ThreadPoolExecutor(max_workers=thread_count)
-	futures = (threadpool.submit(check, self, data[site]['url'].format(self.urlib(query).quote_plus.replace('.','%2E')), site, data) for site in data)
+	futures = (threadpool.submit(check, self, data[site]['url'].format(self.urlib(query).quote_plus.replace('.', '%2E')), site, data) for site in data)
 	for results in concurrent.futures.as_completed(futures):
-		print(f"Found {len(OUTPUT['links'])} accounts" , end= '\r')
+		print(f"Found {len(OUTPUT['links'])} accounts" , end='\r')
 	print('\n')
 
 
@@ -68,19 +68,15 @@ def module_api(self):
 		data = json.load(handle)
 	thread(self, data, query,self.options['thread'])
 	output = OUTPUT
-
 	self.save_gather(
 		output,
 		'osint/username_search',
 		query,
 		output=self.options.get('output')
 	)
-
-    
 	output['links'] = sorted(
 		list(output['links'].items()), key=lambda x: int(x[1]['rank'])
 	)
-
 	return output
 
 def module_run(self):


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

<!-- Short description of what this resolves -->
#### Resolves
In some modules we needed to access the root folder and we used an ugly way with a lot of `os.path.dirname`s
This PR adds a basedir module that allows every module to import the root directory path directly

<!-- Changes proposed in this pull request -->
#### Changes

- added core/basedir.py
- replaced all project_root inside modules with BASEDIR variable

#### Checklist

- [x] I have read the Contribution & Best practices Guideline.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The acceptance, integration, unit tests pass locally with my changes <!-- use `tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)