### PR TITLE
remove_html_tags improvement by unescaping html entities

### DIFF
--- a/core/util/page_parse.py
+++ b/core/util/page_parse.py
@@ -16,6 +16,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import re
+from html import unescape
 from lxml import html
 
 class main:
@@ -87,8 +88,9 @@ class main:
 				flags=re.DOTALL)
 		styles = re.compile(r"<style[^>]*>.*?</style>",
 				flags=re.DOTALL)
-		tags = re.compile(r'<[^>]+>|&nbsp|&amp|&lt|&gt|&quot|&apos')
-		self.page = re.sub(tags, '', re.sub(styles, '', re.sub(scripts, '', self.page)))
+		tags = re.compile(r'<[^>]+>')
+		self.page = re.sub(tags, '', re.sub(styles, '',
+				re.sub(scripts, '', unescape(self.page))))
 
 	@property
 	def remove_comments(self):


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Short description of what this resolves -->
#### Resolves
Instead of trying to remove most common html entities using regex in remove_html_tags,
we should unescape all entities entirely.

<!-- Changes proposed in this pull request -->
#### Changes
- using html.unescape we unescape entities before removing tags in remove_html_tags of core/util/page_parse.py

#### Checklist

- [X] I have read the Contribution & Best practices Guideline.
- [X] My branch is up-to-date with the Upstream `master` branch.
- [ ] The acceptance, integration, unit tests pass locally with my changes <!-- use `tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)