### PR TITLE
Fix quote handling in input

### DIFF
--- a/core/initial.py
+++ b/core/initial.py
@@ -360,7 +360,7 @@ class initialize(core):
 			if self._mode == 'execute':
 				args = parser.parse_args(sys.argv[3:])
 			else:
-				lexer = shlex.split(args)
+				lexer = shlex.split(shlex.quote(args))
 				args = parser.parse_args(lexer)
 			args = vars(args)
 			# Set options


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

<!-- Short description of what this resolves -->
#### Resolves

If a query containing quotes(' or ") was passed in search parameter, for example **McDonald's**, then shlex throws following error
`ValueError: No closing quotation`

Parsing the quotes would resolve the issue

<!-- Changes proposed in this pull request -->
#### Changes

Usage of **shlex.quote** fix the issue

#### Checklist

- [x] I have read the Contribution & Best practices Guideline.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The acceptance, integration, unit tests pass locally with my changes <!-- use `tests/` to run all the tests -->