### PR TITLE
offset set_page in run_crawl by 1 & adds limit to arxiv & fixes djs regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv/
 *.pyc
 __pycache__/
+dist/

--- a/maryam/core/util/engines/baidu.py
+++ b/maryam/core/util/engines/baidu.py
@@ -32,8 +32,8 @@ class main:
 		self.baidu = 'baidu.com'
 
 	def run_crawl(self):
-		set_page = lambda x: x*10
-		urls = [f"http://{self.baidu}/s?wd={self.q}&oq={self.q}&pn={set_page(i)}&ie=utf-8" for i in range(1, self.limit)]
+		set_page = lambda x: (x - 1) * 10 + 1
+		urls = [f"http://{self.baidu}/s?wd={self.q}&oq={self.q}&pn={set_page(i)}&ie=utf-8" for i in range(1, self.limit+1)]
 		max_attempt = len(urls)
 		for url in range(len(urls)):
 			self.framework.verbose(f"[BAIDU] Searching in {url} page...")

--- a/maryam/core/util/engines/bing.py
+++ b/maryam/core/util/engines/bing.py
@@ -42,7 +42,7 @@ class main:
 
 	def run_crawl(self):
 		page = 1
-		set_page = lambda x: x*11
+		set_page = lambda x: (x - 1) * 10 + 1
 		payload = {'count': self.count, 'first': set_page(page), 'form': 'QBLH', 'pq': self.q.lower(), 'q': self.q}
 		max_attempt = 0
 		while True:

--- a/maryam/core/util/engines/millionshort.py
+++ b/maryam/core/util/engines/millionshort.py
@@ -36,7 +36,7 @@ class main:
 
 	def run_crawl(self):
 		page = 1
-		set_page = lambda x: x*10
+		set_page = lambda x: (x - 1) * 10 + 1
 		payload = {'keywords': self.q, 'remove': '0', 'offset': '0'}
 		headers = {
 			"Host": 'millionshort.com',

--- a/maryam/core/util/engines/qwant.py
+++ b/maryam/core/util/engines/qwant.py
@@ -35,8 +35,8 @@ class main:
 		self.qwant = 'https://api.qwant.com/v3/search/web'
 
 	def run_crawl(self):
-		page = 0
-		set_page = lambda x: x*10
+		page = 1
+		set_page = lambda x: (x - 1) * 10 + 1
 		payload = {'q': self.q, 'offset': set_page(page), 'count': '10', 'safesearch': '0', 'device': 'desktop', 'locale': 'en_us'}
 		headers = {'Host': 'api.qwant.com', 
 				   'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:68.0) Gecko/20100101 Firefox/68.0',
@@ -68,9 +68,9 @@ class main:
 						self.framework.error('429 Too Many Requests')
 						return
 					else:
-						page += 1
 						if page == self.limit:
 							break
+						page += 1
 						payload['offset'] = set_page(page)
 
 	@property

--- a/maryam/core/util/engines/yahoo.py
+++ b/maryam/core/util/engines/yahoo.py
@@ -50,7 +50,7 @@ class main:
 
 	def run_crawl(self):
 		page = 1
-		set_page = lambda x: (x*10)+1
+		set_page = lambda x: (x - 1) * 10 + 1
 		payload = {'p': self.q, 'b': set_page(page), 'pz': self.count, 'fl': 1}
 		max_attempt = 0
 		while True:

--- a/maryam/core/util/osint/exalead.py
+++ b/maryam/core/util/osint/exalead.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 class main:
 
-	def __init__(self, q, limit):
+	def __init__(self, q, limit=1):
 		""" exalead.com search engine
 
 			q         : Query for search
@@ -30,9 +30,9 @@ class main:
 		self.limit = limit
 
 	def run_crawl(self):
-		set_page = lambda x:x*10
+		set_page = lambda x: (x - 1) * 10 + 1
 		urls = [f"https://{self.exalead}/search/web/results/?q={self.q.replace(' ', '%20')}&elements_per_page=50&start_index={set_page(i)}" 
-					for i in range(self.limit+1)]
+					for i in range(1, self.limit+1)]
 		max_attempt = len(urls)
 		for url in range(max_attempt):
 			self.framework.debug(f"[EXALEAD] Searching in {url} page...")

--- a/maryam/core/util/search/arxiv.py
+++ b/maryam/core/util/search/arxiv.py
@@ -19,7 +19,7 @@ from lxml import etree
 
 class main:
 
-	def __init__(self, q, limit=15):
+	def __init__(self, q, limit=1):
 		""" arxiv.org search engine
 
 				q         : query for search
@@ -27,9 +27,9 @@ class main:
 		"""
 		self.framework = main.framework
 		self.q = q
-		self.max = limit
-		self._rawxml = ''
+		self.limit = limit
 		self._tree = ''
+		self._rawxml = []
 		self._articles = []
 		self._links = []
 		self._results = []
@@ -37,20 +37,29 @@ class main:
 		self.NSMAP = {'w3':'http://www.w3.org/2005/Atom'}
 
 	def run_crawl(self):
-		payload = {'search_query': f"all:{self.q}", 'start': '0', 'max_results': self.max}
+		page = 1
+		set_start = lambda x: (x - 1) * 10 + 1
+		payload = {'search_query': f"all:{self.q}", 'start': set_start(page)}
 		self.framework.verbose('[ARXIV] Searching the arxiv.org domain...')
-		try:
-			req = self.framework.request(
-					url=self.url,
-					params=payload)
-		except:
-			self.framework.error('ConnectionError', 'arxiv', 'run_crawl')
-			self.framework.error('ArXiv is missed!', 'arxiv', 'run_crawl')
-			return
-		self._rawxml = req.text
-		self._tree = etree.fromstring(req.text.encode('utf-8'))
-		self._articles = self.find(self._tree, './/w3:entry')
 
+		max_attempt = 0
+		while True:
+			try:
+				req = self.framework.request(
+						url=self.url,
+						params=payload)
+			except:
+				self.framework.error('ConnectionError', 'arxiv', 'run_crawl')
+				self.framework.error('ArXiv is missed!', 'arxiv', 'run_crawl')
+				return
+			else:
+				self._rawxml.append(req.text)
+				self._tree = etree.fromstring(req.text.encode('utf-8'))
+				self._articles.extend(self.find(self._tree, './/w3:entry'))
+				if page >= self.limit:
+					break
+				page += 1
+				payload['start'] = set_start(page)
 
 	def find(self, x, tofind):
 		return x.findall(tofind, namespaces=self.NSMAP)

--- a/maryam/modules/search/arxiv.py
+++ b/maryam/modules/search/arxiv.py
@@ -22,9 +22,9 @@ meta = {
 	'sources': ('arxiv',),
 	'options': (
 		('query', None, True, 'Query string', '-q', 'store', str),
-		('limit', 15, False, 'Max result count (default=15)', '-l', 'store', int),
+		('limit', 1, False, 'Max page count (default=1)', '-l', 'store', int),
 	),
-	'examples': ('arxiv -q <QUERY> -l 15 --output',)
+	'examples': ('arxiv -q <QUERY> -l 2 --output',)
 }
 
 def module_api(self):


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Short description of what this resolves -->
#### Resolves
Starting run_crawl from page=1 with `start_page(x) = x*10+1` results in engines starting from 11th result. Also added limit to arxiv and fixed token regex in djs


<!-- Changes proposed in this pull request -->
#### Changes
- `page = 1` and `start_page(x) = (x-1)*10+1` in run_crawl of bing, duckduckgo, millionshort, qwant, baidu, yahoo and exalead.
- Limit added in arxiv
- Fixes djs regex.

#### Checklist

- [X] I have read the Contribution & Best practices Guideline.
- [X] My branch is up-to-date with the Upstream `master` branch.
- [ ] The acceptance, integration, unit tests pass locally with my changes <!-- use `tests/` to run all the tests -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)