### PR TITLE
Fixed the module usage information, "-d <DOMAIN>" is required.

### DIFF
--- a/maryam/modules/footprint/dnsbrute.py
+++ b/maryam/modules/footprint/dnsbrute.py
@@ -25,7 +25,7 @@ meta = {
 	'description': 'DNS brute force attack, supports concurrency.',
 	'comments': ('The wordlist option can be an url',),
 	'options': (
-		('domain', None, False, 'Domain name without https?://', '-d', 'store', str),
+		('domain', None, True, 'Domain name without https?://', '-d', 'store', str),
 		('count', None, False, 'Number of payloads len(max=count of payloads). default is max',
 							 '-c', 'store', int),
 		('wordlist', os.path.join(BASEDIR, 'data', 'dnsnames.txt'), False, 

--- a/maryam/modules/footprint/filebrute.py
+++ b/maryam/modules/footprint/filebrute.py
@@ -27,7 +27,7 @@ meta = {
 	'description': 'File/Directory brute force attack, supports cocurrency.',
 	'comments': ('The wordlist option can be an url.',),
 	'options': (
-		('domain', None, False, 'Domain name without https?://', '-d', 'store', str),
+		('domain', None, True, 'Domain name without https?://', '-d', 'store', str),
 		('count', None, False, 'Number of payloads len(max=count of payloads). default is max',
 							 '-c', 'store', int),
 		('wordlist', 'https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/Web-Content/RobotsDisallowed-Top500.txt', False, 

--- a/maryam/modules/iris/cluster.py
+++ b/maryam/modules/iris/cluster.py
@@ -21,7 +21,7 @@ meta = {
 	'description': 'Cluster your data using kmeans and fp-growth.',
 	'required': ('sklearn', 'kneed', 'mlxtend', 'numpy', 'pandas'),
 	'options': (
-		('json', None, False, 'Json file that contains the data', '-j', 'store', str),
+		('json', None, True, 'Json file that contains the data', '-j', 'store', str),
 	),
 	'examples': ('cluster -j test.json')
 }

--- a/maryam/modules/iris/sentiment.py
+++ b/maryam/modules/iris/sentiment.py
@@ -24,7 +24,7 @@ meta = {
 	'description': 'Running sentiment analysis on your data.',
 	'required': ('vaderSentiment',),
 	'options': (
-		('json', None, False, 'Json file that contains the data', '-j', 'store', str),
+		('json', None, True, 'Json file that contains the data', '-j', 'store', str),
 		('key', '', False, 'Data key. the value should be a list. None means the json file contains a list: ["..", ..]', '-k', 'store', str),
 		('thread', 5, False, 'The number of thread per each sell(default=10)', '-t', 'store', int),
 		('pipe', False, False, 'Dev only! pipe data from other modules(default=False)', '-p', 'store_true', bool),

--- a/maryam/modules/osint/dns_search.py
+++ b/maryam/modules/osint/dns_search.py
@@ -28,7 +28,7 @@ meta = {
 				'urlscan', 'gigablast', 'dogpile'),
 	'options': (
 		('domain', None,
-		 False, 'Domain name without https?://', '-d', 'store', str),
+		 True, 'Domain name without https?://', '-d', 'store', str),
 		('limit', 3, False, 'Search limit(number of pages, default=3)', '-l', 'store', int),
 		('count', 30, False, 'number of results per page(min=10, max=100, default=30)', '-c', 'store', int),
 		('engines', 'otx,securitytrails', False, 'Search engine names. e.g bing,google,...[otx by default]', '-e', 'store', str),


### PR DESCRIPTION
for the Footprint's DnsBrute and FileBrute modules