### PR TITLE
Fix Python 3.12 Syntax Warnings (use raw strings)

### DIFF
--- a/maryam/core/util/helpers/web_scrap.py
+++ b/maryam/core/util/helpers/web_scrap.py
@@ -136,7 +136,7 @@ class main:
 			if cond1:
 				continue
 
-			join = str(join).replace('\/', '/')
+			join = str(join).replace(r'\/', '/')
 			##########################
 			# ADD OUT SCOPE
 			##########################

--- a/maryam/core/util/iris/cluster.py
+++ b/maryam/core/util/iris/cluster.py
@@ -31,7 +31,7 @@ class main:
 		return [x for x in text if x not in stops]
 
 	def tokenize_and_stem(self, text):
-		tokens = re.findall("[A-Z]{2,}(?![a-z])|[A-Z][a-z]+(?=[A-Z])|[\'\w\-]+",text)
+		tokens = re.findall(r"[A-Z]{2,}(?![a-z])|[A-Z][a-z]+(?=[A-Z])|[\'\w\-]+",text)
 		filtered_tokens = []
 		for token in tokens:
 			if re.search('[a-zA-Z]', token):

--- a/maryam/modules/footprint/crawl_pages.py
+++ b/maryam/modules/footprint/crawl_pages.py
@@ -30,7 +30,7 @@ meta = {
 		('debug', False, False, 'debug the scraper', '--debug', 'store_true', bool),
 		('thread', 1, False, 'The number of links that open per round', '-t', 'store', int),
 	),
-	'examples': ('crawl_pages -d <DOMAIN> -r "https?://[A-z0-9\./]+"\
+	'examples': (r'crawl_pages -d <DOMAIN> -r "https?://[A-z0-9\./]+"\
 	 --output', 'crawl_pages -d <DOMAIN> --limit 2 --more')
 }
 

--- a/maryam/modules/osint/cloud_storage.py
+++ b/maryam/modules/osint/cloud_storage.py
@@ -70,7 +70,7 @@ def module_api(self):
 		self.thread(search, self.options['thread'], engine, query, q_formats, limit, count, meta['sources'])
 			
 		output['links'] += list( self.reglib().filter(r"https?://([\w\-\.]+\.)?"\
-		+ site_url.replace('.','\.')+"/", list( set(LINKS) ) ) ) #escaping . for regex search using replace()
+		+ site_url.replace('.',r'\.')+"/", list( set(LINKS) ) ) ) #escaping . for regex search using replace()
 
 	self.save_gather(output, 'osint/cloud_storage', query, output=self.options.get('output'))
 	return output


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #287 

<!-- Short description of what this resolves -->
#### Resolves

Python3.12 `SyntaxWarning: invalid escape sequence` in various helper and/or module scripts

<!-- Changes proposed in this pull request -->
#### Changes

- Use raw strings for the affected scripts containing invalid escape sequences

#### Checklist

- [x] I have read the Contribution & Best practices Guideline.
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The acceptance, integration, unit tests pass locally with my changes <!-- use `tests/` to run all the tests -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)